### PR TITLE
Hypermutated sample fix

### DIFF
--- a/conda/vcf_stuff/meta.yaml
+++ b/conda/vcf_stuff/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - cyvcf2 >=0.10.0
     - numpy >=1.15.0
     - pandas
-    - ngs_utils
     - nose
     - bed_annotation >=1.1.4
     - reference_data


### PR DESCRIPTION
We've opted to use a BED file with all gene regions to subset hypermutated (>500K SNVs) samples. Removing the PCGR hack that filtered down to only coding regions.
The algo is:

- if >500K SNVs in input VCF, try filtering out those where `gnomAD_AF > 0.01` (and not in hotspot).
  - if that brings it <500K, great, just copy the result to the final output
  - if we still have >500K, subset to the all-gene BED file.

We also write the count stats to the yaml file.